### PR TITLE
Allow the WellKnownAddress option to just have a host name.

### DIFF
--- a/bedrock-coherence/12.2.1.4/coherence-12.2.1.4-tests/src/test/java/com/oracle/bedrock/runtime/coherence/AbstractCoherenceClusterBuilderTest.java
+++ b/bedrock-coherence/12.2.1.4/coherence-12.2.1.4-tests/src/test/java/com/oracle/bedrock/runtime/coherence/AbstractCoherenceClusterBuilderTest.java
@@ -173,7 +173,7 @@ public abstract class AbstractCoherenceClusterBuilderTest extends AbstractTest
     public void shouldBuilderWKABasedStorageCluster()
     {
         Capture<Integer>        wkaPort            = new Capture<>(LocalPlatform.get().getAvailablePorts());
-        ClusterPort             clusterPort = ClusterPort.of(new Capture<>(LocalPlatform.get().getAvailablePorts()));
+        ClusterPort             clusterPort        = ClusterPort.of(new Capture<>(LocalPlatform.get().getAvailablePorts()));
         String                  localHost          = System.getProperty("tangosol.coherence.localhost", "127.0.0.1");
 
         String                  clusterName        = "WKA" + getClass().getSimpleName();
@@ -186,7 +186,7 @@ public abstract class AbstractCoherenceClusterBuilderTest extends AbstractTest
                                CoherenceClusterMember.class,
                                DisplayName.of("storage"),
                                LocalStorage.enabled(),
-                               WellKnownAddress.of(localHost, wkaPort),
+                               WellKnownAddress.of(localHost),
                                ClusterName.of(clusterName),
                                LocalHost.of(localHost, wkaPort),
                                clusterPort);
@@ -209,9 +209,6 @@ public abstract class AbstractCoherenceClusterBuilderTest extends AbstractTest
         AvailablePortIterator   availablePorts = LocalPlatform.get().getAvailablePorts();
         ClusterPort             clusterPort    = ClusterPort.of(new Capture<>(availablePorts));
         String                  clusterName    = "Rolling" + getClass().getSimpleName();
-
-        Platform                platform       = getPlatform();
-
         CoherenceClusterBuilder builder        = new CoherenceClusterBuilder();
 
         builder.include(CLUSTER_SIZE,

--- a/bedrock-coherence/12.2.1.4/coherence-12.2.1.4-tests/src/test/java/com/oracle/bedrock/runtime/coherence/ContainerBasedCoherenceCacheServerIT.java
+++ b/bedrock-coherence/12.2.1.4/coherence-12.2.1.4-tests/src/test/java/com/oracle/bedrock/runtime/coherence/ContainerBasedCoherenceCacheServerIT.java
@@ -37,7 +37,7 @@ import com.oracle.bedrock.runtime.java.JavaVirtualMachine;
  *
  * @author Brian Oliver
  */
-public class ContainerBasedCoherenceCacheServerTest extends AbstractCoherenceCacheServerTest
+public class ContainerBasedCoherenceCacheServerIT extends AbstractCoherenceCacheServerTest
 {
     @Override
     public Platform getPlatform()

--- a/bedrock-coherence/12.2.1.4/coherence-12.2.1.4-tests/src/test/java/com/oracle/bedrock/runtime/coherence/ContainerBasedCoherenceClusterBuilderIT.java
+++ b/bedrock-coherence/12.2.1.4/coherence-12.2.1.4-tests/src/test/java/com/oracle/bedrock/runtime/coherence/ContainerBasedCoherenceClusterBuilderIT.java
@@ -1,5 +1,5 @@
 /*
- * File: LocalCoherenceCacheServerTest.java
+ * File: ContainerBasedCoherenceClusterBuilderTest.java
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
@@ -25,23 +25,33 @@
 
 package com.oracle.bedrock.runtime.coherence;
 
-import com.oracle.bedrock.runtime.LocalPlatform;
 import com.oracle.bedrock.runtime.Platform;
-import com.oracle.bedrock.runtime.java.LocalJavaApplicationLauncher;
+import com.oracle.bedrock.runtime.java.ContainerBasedJavaApplicationLauncher;
+import com.oracle.bedrock.runtime.java.JavaVirtualMachine;
+import org.junit.Ignore;
 
 /**
- * Functional Test for {@link CoherenceCacheServer}s using a {@link LocalJavaApplicationLauncher}.
+ * Functional Tests for {@link CoherenceClusterBuilder}s using a {@link ContainerBasedJavaApplicationLauncher}.
  * <p>
  * Copyright (c) 2014. All Rights Reserved. Oracle Corporation.<br>
  * Oracle is a registered trademark of Oracle Corporation and/or its affiliates.
  *
  * @author Brian Oliver
  */
-public class LocalCoherenceCacheServerTest extends AbstractCoherenceCacheServerTest
+public class ContainerBasedCoherenceClusterBuilderIT extends AbstractCoherenceClusterBuilderTest
 {
     @Override
     public Platform getPlatform()
     {
-        return LocalPlatform.get();
+        return JavaVirtualMachine.get();
+    }
+
+
+    @Override
+    @Ignore
+    public void shouldPerformRollingRestartOfCluster()
+    {
+        // we skip this test as performing a rolling restart in single JVM
+        // container is not supported for Coherence
     }
 }

--- a/bedrock-coherence/12.2.1.4/coherence-12.2.1.4-tests/src/test/java/com/oracle/bedrock/runtime/coherence/LocalCoherenceCacheServerIT.java
+++ b/bedrock-coherence/12.2.1.4/coherence-12.2.1.4-tests/src/test/java/com/oracle/bedrock/runtime/coherence/LocalCoherenceCacheServerIT.java
@@ -1,5 +1,5 @@
 /*
- * File: ContainerBasedCoherenceClusterBuilderTest.java
+ * File: LocalCoherenceCacheServerTest.java
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
@@ -25,33 +25,23 @@
 
 package com.oracle.bedrock.runtime.coherence;
 
+import com.oracle.bedrock.runtime.LocalPlatform;
 import com.oracle.bedrock.runtime.Platform;
-import com.oracle.bedrock.runtime.java.ContainerBasedJavaApplicationLauncher;
-import com.oracle.bedrock.runtime.java.JavaVirtualMachine;
-import org.junit.Ignore;
+import com.oracle.bedrock.runtime.java.LocalJavaApplicationLauncher;
 
 /**
- * Functional Tests for {@link CoherenceClusterBuilder}s using a {@link ContainerBasedJavaApplicationLauncher}.
+ * Functional Test for {@link CoherenceCacheServer}s using a {@link LocalJavaApplicationLauncher}.
  * <p>
  * Copyright (c) 2014. All Rights Reserved. Oracle Corporation.<br>
  * Oracle is a registered trademark of Oracle Corporation and/or its affiliates.
  *
  * @author Brian Oliver
  */
-public class ContainerBasedCoherenceClusterBuilderTest extends AbstractCoherenceClusterBuilderTest
+public class LocalCoherenceCacheServerIT extends AbstractCoherenceCacheServerTest
 {
     @Override
     public Platform getPlatform()
     {
-        return JavaVirtualMachine.get();
-    }
-
-
-    @Override
-    @Ignore
-    public void shouldPerformRollingRestartOfCluster()
-    {
-        // we skip this test as performing a rolling restart in single JVM
-        // container is not supported for Coherence
+        return LocalPlatform.get();
     }
 }

--- a/bedrock-coherence/12.2.1.4/coherence-12.2.1.4-tests/src/test/java/com/oracle/bedrock/runtime/coherence/LocalCoherenceClusterBuilderIT.java
+++ b/bedrock-coherence/12.2.1.4/coherence-12.2.1.4-tests/src/test/java/com/oracle/bedrock/runtime/coherence/LocalCoherenceClusterBuilderIT.java
@@ -59,7 +59,7 @@ import static org.hamcrest.CoreMatchers.is;
  *
  * @author Brian Oliver
  */
-public class LocalCoherenceClusterBuilderTest extends AbstractCoherenceClusterBuilderTest
+public class LocalCoherenceClusterBuilderIT extends AbstractCoherenceClusterBuilderTest
 {
     @Override
     public Platform getPlatform()

--- a/bedrock-coherence/12.2.1/coherence-12.2.1-tests/src/test/java/com/oracle/bedrock/runtime/coherence/AbstractCoherenceClusterBuilderTest.java
+++ b/bedrock-coherence/12.2.1/coherence-12.2.1-tests/src/test/java/com/oracle/bedrock/runtime/coherence/AbstractCoherenceClusterBuilderTest.java
@@ -173,7 +173,7 @@ public abstract class AbstractCoherenceClusterBuilderTest extends AbstractTest
     public void shouldBuilderWKABasedStorageCluster()
     {
         Capture<Integer>        wkaPort            = new Capture<>(LocalPlatform.get().getAvailablePorts());
-        ClusterPort             clusterPort = ClusterPort.of(new Capture<>(LocalPlatform.get().getAvailablePorts()));
+        ClusterPort             clusterPort        = ClusterPort.of(new Capture<>(LocalPlatform.get().getAvailablePorts()));
         String                  localHost          = System.getProperty("tangosol.coherence.localhost", "127.0.0.1");
 
         String                  clusterName        = "WKA" + getClass().getSimpleName();
@@ -186,7 +186,7 @@ public abstract class AbstractCoherenceClusterBuilderTest extends AbstractTest
                                CoherenceClusterMember.class,
                                DisplayName.of("storage"),
                                LocalStorage.enabled(),
-                               WellKnownAddress.of(localHost, wkaPort),
+                               WellKnownAddress.of(localHost),
                                ClusterName.of(clusterName),
                                LocalHost.of(localHost, wkaPort),
                                clusterPort);
@@ -209,9 +209,6 @@ public abstract class AbstractCoherenceClusterBuilderTest extends AbstractTest
         AvailablePortIterator   availablePorts = LocalPlatform.get().getAvailablePorts();
         ClusterPort             clusterPort    = ClusterPort.of(new Capture<>(availablePorts));
         String                  clusterName    = "Rolling" + getClass().getSimpleName();
-
-        Platform                platform       = getPlatform();
-
         CoherenceClusterBuilder builder        = new CoherenceClusterBuilder();
 
         builder.include(CLUSTER_SIZE,

--- a/bedrock-coherence/12.2.1/coherence-12.2.1-tests/src/test/java/com/oracle/bedrock/runtime/coherence/ContainerBasedCoherenceCacheServerIT.java
+++ b/bedrock-coherence/12.2.1/coherence-12.2.1-tests/src/test/java/com/oracle/bedrock/runtime/coherence/ContainerBasedCoherenceCacheServerIT.java
@@ -37,7 +37,7 @@ import com.oracle.bedrock.runtime.java.JavaVirtualMachine;
  *
  * @author Brian Oliver
  */
-public class ContainerBasedCoherenceCacheServerTest extends AbstractCoherenceCacheServerTest
+public class ContainerBasedCoherenceCacheServerIT extends AbstractCoherenceCacheServerTest
 {
     @Override
     public Platform getPlatform()

--- a/bedrock-coherence/12.2.1/coherence-12.2.1-tests/src/test/java/com/oracle/bedrock/runtime/coherence/ContainerBasedCoherenceClusterBuilderIT.java
+++ b/bedrock-coherence/12.2.1/coherence-12.2.1-tests/src/test/java/com/oracle/bedrock/runtime/coherence/ContainerBasedCoherenceClusterBuilderIT.java
@@ -1,5 +1,5 @@
 /*
- * File: LocalCoherenceCacheServerTest.java
+ * File: ContainerBasedCoherenceClusterBuilderTest.java
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
@@ -25,23 +25,33 @@
 
 package com.oracle.bedrock.runtime.coherence;
 
-import com.oracle.bedrock.runtime.LocalPlatform;
 import com.oracle.bedrock.runtime.Platform;
-import com.oracle.bedrock.runtime.java.LocalJavaApplicationLauncher;
+import com.oracle.bedrock.runtime.java.ContainerBasedJavaApplicationLauncher;
+import com.oracle.bedrock.runtime.java.JavaVirtualMachine;
+import org.junit.Ignore;
 
 /**
- * Functional Test for {@link CoherenceCacheServer}s using a {@link LocalJavaApplicationLauncher}.
+ * Functional Tests for {@link CoherenceClusterBuilder}s using a {@link ContainerBasedJavaApplicationLauncher}.
  * <p>
  * Copyright (c) 2014. All Rights Reserved. Oracle Corporation.<br>
  * Oracle is a registered trademark of Oracle Corporation and/or its affiliates.
  *
  * @author Brian Oliver
  */
-public class LocalCoherenceCacheServerTest extends AbstractCoherenceCacheServerTest
+public class ContainerBasedCoherenceClusterBuilderIT extends AbstractCoherenceClusterBuilderTest
 {
     @Override
     public Platform getPlatform()
     {
-        return LocalPlatform.get();
+        return JavaVirtualMachine.get();
+    }
+
+
+    @Override
+    @Ignore
+    public void shouldPerformRollingRestartOfCluster()
+    {
+        // we skip this test as performing a rolling restart in single JVM
+        // container is not supported for Coherence
     }
 }

--- a/bedrock-coherence/12.2.1/coherence-12.2.1-tests/src/test/java/com/oracle/bedrock/runtime/coherence/LocalCoherenceCacheServerIT.java
+++ b/bedrock-coherence/12.2.1/coherence-12.2.1-tests/src/test/java/com/oracle/bedrock/runtime/coherence/LocalCoherenceCacheServerIT.java
@@ -1,5 +1,5 @@
 /*
- * File: ContainerBasedCoherenceClusterBuilderTest.java
+ * File: LocalCoherenceCacheServerTest.java
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
@@ -25,33 +25,23 @@
 
 package com.oracle.bedrock.runtime.coherence;
 
+import com.oracle.bedrock.runtime.LocalPlatform;
 import com.oracle.bedrock.runtime.Platform;
-import com.oracle.bedrock.runtime.java.ContainerBasedJavaApplicationLauncher;
-import com.oracle.bedrock.runtime.java.JavaVirtualMachine;
-import org.junit.Ignore;
+import com.oracle.bedrock.runtime.java.LocalJavaApplicationLauncher;
 
 /**
- * Functional Tests for {@link CoherenceClusterBuilder}s using a {@link ContainerBasedJavaApplicationLauncher}.
+ * Functional Test for {@link CoherenceCacheServer}s using a {@link LocalJavaApplicationLauncher}.
  * <p>
  * Copyright (c) 2014. All Rights Reserved. Oracle Corporation.<br>
  * Oracle is a registered trademark of Oracle Corporation and/or its affiliates.
  *
  * @author Brian Oliver
  */
-public class ContainerBasedCoherenceClusterBuilderTest extends AbstractCoherenceClusterBuilderTest
+public class LocalCoherenceCacheServerIT extends AbstractCoherenceCacheServerTest
 {
     @Override
     public Platform getPlatform()
     {
-        return JavaVirtualMachine.get();
-    }
-
-
-    @Override
-    @Ignore
-    public void shouldPerformRollingRestartOfCluster()
-    {
-        // we skip this test as performing a rolling restart in single JVM
-        // container is not supported for Coherence
+        return LocalPlatform.get();
     }
 }

--- a/bedrock-coherence/12.2.1/coherence-12.2.1-tests/src/test/java/com/oracle/bedrock/runtime/coherence/LocalCoherenceClusterBuilderIT.java
+++ b/bedrock-coherence/12.2.1/coherence-12.2.1-tests/src/test/java/com/oracle/bedrock/runtime/coherence/LocalCoherenceClusterBuilderIT.java
@@ -59,7 +59,7 @@ import static org.hamcrest.CoreMatchers.is;
  *
  * @author Brian Oliver
  */
-public class LocalCoherenceClusterBuilderTest extends AbstractCoherenceClusterBuilderTest
+public class LocalCoherenceClusterBuilderIT extends AbstractCoherenceClusterBuilderTest
 {
     @Override
     public Platform getPlatform()

--- a/bedrock-coherence/12.2.1/coherence-12.2.1/src/main/java/com/oracle/bedrock/runtime/coherence/options/WellKnownAddress.java
+++ b/bedrock-coherence/12.2.1/coherence-12.2.1/src/main/java/com/oracle/bedrock/runtime/coherence/options/WellKnownAddress.java
@@ -1,0 +1,257 @@
+/*
+ * File: WellKnownAddress.java
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * The contents of this file are subject to the terms and conditions of 
+ * the Common Development and Distribution License 1.0 (the "License").
+ *
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the License by consulting the LICENSE.txt file
+ * distributed with this file, or by consulting https://oss.oracle.com/licenses/CDDL
+ *
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file LICENSE.txt.
+ *
+ * MODIFICATIONS:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ */
+
+package com.oracle.bedrock.runtime.coherence.options;
+
+import com.oracle.bedrock.Option;
+import com.oracle.bedrock.OptionsByType;
+import com.oracle.bedrock.runtime.Application;
+import com.oracle.bedrock.runtime.MetaClass;
+import com.oracle.bedrock.runtime.Platform;
+import com.oracle.bedrock.runtime.Profile;
+import com.oracle.bedrock.runtime.coherence.CoherenceClusterMember;
+import com.oracle.bedrock.runtime.java.options.SystemProperties;
+import com.oracle.bedrock.runtime.java.options.SystemProperty;
+import com.oracle.bedrock.runtime.network.AvailablePortIterator;
+import com.oracle.bedrock.util.Capture;
+import com.oracle.bedrock.util.PerpetualIterator;
+
+import java.util.Iterator;
+
+/**
+ * An {@link Option} to specify the well known address and port of a {@link CoherenceClusterMember}.
+ * <p>
+ * Copyright (c) 2016. All Rights Reserved. Oracle Corporation.<br>
+ * Oracle is a registered trademark of Oracle Corporation and/or its affiliates.
+ *
+ * @author Brian Oliver
+ */
+public class WellKnownAddress implements Profile, Option
+{
+    /**
+     * The tangosol.coherence.wka property.
+     */
+    public static final String PROPERTY = "tangosol.coherence.wka";
+
+    /**
+     * The tangosol.coherence.wka.port property.
+     */
+    public static final String PROPERTY_PORT = "tangosol.coherence.wka.port";
+
+    /**
+     * The well known address of an {@link CoherenceClusterMember}.
+     */
+    private String address;
+
+    /**
+     * The well known address port for a {@link CoherenceClusterMember}.
+     */
+    private Iterator<Integer> ports;
+
+
+    /**
+     * Constructs a {@link WellKnownAddress}.
+     *
+     * @param address the address
+     */
+    private WellKnownAddress(String            address,
+                             Iterator<Integer> ports)
+    {
+        this.address = address;
+        this.ports   = ports;
+    }
+
+
+    /**
+     * Obtains the address of the {@link WellKnownAddress}.
+     *
+     * @return the address of the {@link WellKnownAddress}
+     */
+    public String getAddress()
+    {
+        return address;
+    }
+
+
+    /**
+     * Obtains the possible ports of the {@link WellKnownAddress}.
+     *
+     * @return the possible ports of the {@link WellKnownAddress}
+     */
+    public Iterator<Integer> getPorts()
+    {
+        return ports;
+    }
+
+
+    /**
+     * Obtains a {@link WellKnownAddress} for a specified address and port.
+     *
+     * @param address the address of the {@link WellKnownAddress}
+     * @param port    the port of the {@link WellKnownAddress}
+     *
+     * @return a {@link WellKnownAddress} for the specified address and port
+     */
+    public static WellKnownAddress of(String address,
+                                      int    port)
+    {
+        return new WellKnownAddress(address, new PerpetualIterator<>(port));
+    }
+
+
+    /**
+     * Obtains a {@link WellKnownAddress} for a specified address and port.
+     *
+     * @param address the address of the {@link WellKnownAddress}
+     * @param port    the port of the {@link WellKnownAddress}
+     *
+     * @return a {@link WellKnownAddress} for the specified address and port
+     */
+    public static WellKnownAddress of(String           address,
+                                      Capture<Integer> port)
+    {
+        return new WellKnownAddress(address, port);
+    }
+
+
+    /**
+     * Obtains a {@link WellKnownAddress} for a specified address and ports.
+     *
+     * @param address the address of the {@link WellKnownAddress}
+     * @param ports   the ports of the {@link WellKnownAddress}
+     *
+     * @return a {@link WellKnownAddress} for the specified address and ports
+     */
+    public static WellKnownAddress of(String            address,
+                                      Iterator<Integer> ports)
+    {
+        return new WellKnownAddress(address, ports);
+    }
+
+
+    /**
+     * Obtains a {@link WellKnownAddress} for a specified address and ports.
+     *
+     * @param address the address of the {@link WellKnownAddress}
+     * @param ports   the ports of the {@link WellKnownAddress}
+     *
+     * @return a {@link WellKnownAddress} for the specified address and ports
+     */
+    public static WellKnownAddress of(String                address,
+                                      AvailablePortIterator ports)
+    {
+        return new WellKnownAddress(address, ports);
+    }
+
+
+    /**
+     * Obtains a {@link WellKnownAddress} for a specified address.
+     *
+     * @param address the address of the {@link WellKnownAddress}
+     *
+     * @return a {@link WellKnownAddress} for the specified address
+     */
+    public static WellKnownAddress of(String address)
+    {
+        return new WellKnownAddress(address, null);
+    }
+
+
+    @Override
+    public void onLaunching(Platform      platform,
+                            MetaClass     metaClass,
+                            OptionsByType optionsByType)
+    {
+        if (ports != null && !ports.hasNext())
+        {
+            throw new IllegalStateException("Exhausted the available ports for the WellKnownAddress");
+        }
+        else
+        {
+            SystemProperties systemProperties = optionsByType.get(SystemProperties.class);
+
+            if (systemProperties != null)
+            {
+                optionsByType.add(SystemProperty.of(PROPERTY, address));
+                if (ports != null)
+                {
+                    optionsByType.add(SystemProperty.of(PROPERTY_PORT, ports.next()));
+                }
+            }
+        }
+    }
+
+
+    @Override
+    public void onLaunched(Platform      platform,
+                           Application   application,
+                           OptionsByType optionsByType)
+    {
+    }
+
+
+    @Override
+    public void onClosing(Platform      platform,
+                          Application   application,
+                          OptionsByType optionsByType)
+    {
+    }
+
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+
+        if (!(o instanceof WellKnownAddress))
+        {
+            return false;
+        }
+
+        WellKnownAddress that = (WellKnownAddress) o;
+
+        if (address != null ? !address.equals(that.address) : that.address != null)
+        {
+            return false;
+        }
+
+        return ports != null ? ports.equals(that.ports) : that.ports == null;
+
+    }
+
+
+    @Override
+    public int hashCode()
+    {
+        int result = address != null ? address.hashCode() : 0;
+
+        result = 31 * result + (ports != null ? ports.hashCode() : 0);
+
+        return result;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <maven.deploy.plugin.version>3.0.0-M1</maven.deploy.plugin.version>
         <maven.doxia.markdown.plugin.version>1.6</maven.doxia.markdown.plugin.version>
         <maven.enforcer.plugin.version>3.0.0-M2</maven.enforcer.plugin.version>
-        <maven.failsafe.plugin.version>3.0.0-M3</maven.failsafe.plugin.version>
+        <maven.failsafe.plugin.version>2.21.0</maven.failsafe.plugin.version>
         <maven.flatten.plugin.version>1.1.0</maven.flatten.plugin.version>
         <maven.github.site.plugin.version>0.10-RC1</maven.github.site.plugin.version>
         <maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>
@@ -115,7 +115,7 @@
         <maven.shade.plugin.version>3.2.1</maven.shade.plugin.version>
         <maven.site.plugin.version>3.7.1</maven.site.plugin.version>
         <maven.source.plugin.version>3.0.1</maven.source.plugin.version>
-        <maven.surefire.plugin.version>3.0.0-M3</maven.surefire.plugin.version>
+        <maven.surefire.plugin.version>2.21.0</maven.surefire.plugin.version>
 
         <!-- dependency versions -->
         <aether.version>1.1.0</aether.version>
@@ -290,7 +290,18 @@
                     <systemPropertyVariables>
                         <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
                     </systemPropertyVariables>
+                    <reuseForks>false</reuseForks>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>verify</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
Allow the WellKnownAddress option to just have a host name. 
Rename certain Coherence tests to *IT so that they run using Failsafe.